### PR TITLE
Fix warning for count() in due of PHP>=7.2

### DIFF
--- a/classes/task/process_duplicate_queue.php
+++ b/classes/task/process_duplicate_queue.php
@@ -48,6 +48,10 @@ class process_duplicate_queue extends \core\task\scheduled_task {
         mtrace('Processing course duplication queue …');
         $info = $queue->process_queue();
 
+        if (!is_array($info)) {
+            return;
+        }
+
         $processedcount = count($info['succeeded']) + count($info['failed']);
         mtrace("Queue processed: $processedcount jobs processed.");
         if (count($info['succeeded'])) {


### PR DESCRIPTION
Hello @OdyX 

Would be great if you can have a look to this patch. It resolves the problems mentioned [here](https://www.php.net/manual/de/function.count.php#refsect1-function.count-changelog).

Greets
Adrian